### PR TITLE
Product cannot be nil

### DIFF
--- a/lib/hdfveiculos.rb
+++ b/lib/hdfveiculos.rb
@@ -33,7 +33,8 @@ module Hdfveiculos
           cpf: parsed_email['n_do_cpf'].split.first
         },
         product: {
-          link: parsed_email['page_url'].split.first
+          link: parsed_email['page_url'].split.first,
+          name: ''
         },
         message: "Valor de entrada: R$ #{parsed_email['qual_valor_da_entrada']} - Possui CNH: #{parsed_email['possui_cnh']}"
       }

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -41,5 +41,9 @@ RSpec.describe F1SalesCustom::Email::Parser do
     it 'contains message' do
       expect(parsed_email[:message]).to eq('Valor de entrada: R$ 6.000 - Possui CNH: Não')
     end
+
+    it 'contains product name' do
+      expect(parsed_email[:product][:name]).to eq('')
+    end
   end
 end


### PR DESCRIPTION
The product name can't be nil, because the method `normalize_name` in `lib/email_processor.rb:63` cannot receive null value.